### PR TITLE
Improve one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,21 @@ This is useful if you work on a project that squashes branches into master. Afte
 To run as a shellscript, simply copy the following command (setting up an alias is recommended). There's no need to clone the repo.
 
 ```bash
-git checkout -q master && git for-each-ref refs/heads/ "--format=%(refname:short)" | while read branch; do mergeBase=$(git merge-base master $branch) && [[ $(git cherry master $(git commit-tree $(git rev-parse $branch\^{tree}) -p $mergeBase -m _)) == "-"* ]] && git branch -D $branch; done
+git for-each-ref --format '%(objectname) %(tree) %(refname)' refs/heads/ |
+while read head tree branch
+do
+    mergeBase=$(git merge-base master "$head")
+    squash=$(git commit-tree -F - -p "$mergeBase" "$tree" </dev/null)
+    case $(git cherry master "$squash") in
+    -*)
+        echo "- $branch"
+        git update-ref -d "$branch" "$head"
+        ;;
+    *)
+        echo "+ $branch"
+        ;;
+    esac
+done
 ```
 
 ### Node.js


### PR DESCRIPTION
Hi Teddy, thanks a lot for this little tool! I've wanted something like this for a long time, but somehow never thought to write it.

I'd like to suggest some changes to your shell version, feel free to use or ignore any of it ;-)

For easier readability, I've formatted the one-liner as a multi-line script. Specifically, it contains the  following changes:

* Use `for-each-ref` to extract the `tree` of each branch, saving a call to `rev-parse`.
* Use the precise commit referenced by the branch for the squash merge.
* Use `update-ref` to delete the branch only if it refers to the precise commit used for the squash.
* Add output similar to `git cherry`.
* Remove depenency on `bash` by using Bourne shell syntax.